### PR TITLE
Print offenses when failure

### DIFF
--- a/lib/index.rb
+++ b/lib/index.rb
@@ -120,7 +120,14 @@ def run
 
     update_check(id, conclusion, output)
 
-    raise if conclusion == 'failure'
+    # Print offenses
+    if conclusion == 'failure'
+      puts output[:summary]
+      output['annotations'].each do |annotation|
+        puts "L#{annotation['start_line']}-L#{annotation['end_line']}:#{annotation['message']}"
+      end
+      raise 'Rubocop found offenses'
+    end
   rescue StandardError
     update_check(id, 'failure', nil)
     raise


### PR DESCRIPTION
Currently when Rubocop finds offenses it raises an exception and that is
it. With this change it will print out the offenses to let the user know
why it's failing.

Today the output looks like this when there's a failure
```shell
Traceback (most recent call last):
	1: from ./index.rb:139:in `<main>'
./index.rb:132:in `run': unhandled exception
```

With this PR the output will look like this
```shell
2 offense(s) found
L17-L17:Style/StringConcatenation: Prefer string interpolation to string concatenation.
L17-L17:Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
Traceback (most recent call last):
	1: from ./index.rb:138:in `<main>'
./index.rb:130:in `run': Rubocop found offenses (RuntimeError)
```

I'm using this workflow for one of my repos and I didn't understand why it was failing, hence making this change. I'm not used to writing Ruby so feel free to change the style of the code.